### PR TITLE
Merge 'pimost' into 'master'

### DIFF
--- a/V-Link.py
+++ b/V-Link.py
@@ -55,6 +55,7 @@ from backend.rti                 import RTIThread
 from backend.can                 import CANThread
 from backend.lin                 import LINThread
 from backend.ign                 import IGNThread
+from backend.pimost              import PiMOSTThread
 
 from backend.shared.shared_state import shared_state
 
@@ -78,6 +79,9 @@ class VLINK:
           
             'vcan':     VCANThread,
         }
+
+        if shared_state.pimost:
+            self.threads['pimost'] = PiMOSTThread
 
     def detect_rpi(self):
 
@@ -126,7 +130,10 @@ class VLINK:
         self.start_thread('adc')
         time.sleep(.5)
         self.start_thread('app')
-        
+            
+        if shared_state.pimost:
+            time.sleep(1)
+            self.start_thread('pimost')
 
     def start_thread(self, thread_name):
         if thread_name in shared_state.THREADS:

--- a/backend/pimost.py
+++ b/backend/pimost.py
@@ -1,0 +1,146 @@
+import threading
+import time
+import sys
+import os
+import subprocess
+import socketio
+import serial
+import struct
+from threading import Thread
+from serial.tools import list_ports
+from .shared.shared_state import shared_state
+import time
+
+# pymost-client implementation, replaced timer with thread
+class PiMost:
+    def __init__(self, recv_most_message):
+        self.port = None
+        self.ser = None
+        self.VID = 51966
+        self.connected = False
+        self.recv_most_message = recv_most_message
+        self.poll_pimost = Thread(target=self.poll)
+        self.poll_pimost.setDaemon(True)
+        self.poll_pimost.start()
+
+        self._out_messages = {
+            'force_switch': bytearray([0x55, 0x01, 0x74])
+        }
+
+    def force_switch(self):
+        if self.connected:
+            self.ser.write(self._out_messages['force_switch'])
+        return
+
+    def send_message(self):
+        return
+
+    def connect(self):
+        self.ser = serial.Serial(port=self.port, baudrate=921600, bytesize=8, timeout=2)
+        self.connected = True
+
+    def find_port(self):
+        device_list = list_ports.comports()
+        print("Finding PiMost port")
+        for device in device_list:
+            if device.vid is not None or device.pid is not None:
+                if device.vid == self.VID:
+                    self.port = device.device
+                    self.connect()
+                    print("Found PiMost device")
+                    break
+
+    def poll(self):
+        while True:
+            if self.connected:
+                try:
+                    # noinspection PyUnresolvedReferences
+                    command = self.ser.read(3)
+                    if len(command) > 0:
+                        if command[0] == 85:
+                            length = command[1]
+                            type = command[2]
+                            # noinspection PyUnresolvedReferences
+                            message = self.ser.read(length)
+                            if type == 0x01:
+                                self.parse_message(message, length)
+                except serial.serialutil.SerialException:
+                    print("PiMost Disconnected")
+                    self.connected = False
+                    self.ser = None
+                    self.port = None
+
+    def parse_message(self, data, length):
+        raw_data = struct.unpack_from('>BBBBBHB', data, 0)
+        message = data[8:len(data)]
+        most_message = {
+            'type': raw_data[0],
+            'source_address_high': raw_data[1],
+            'source_address_low': raw_data[2],
+            'fBlock_id': raw_data[3],
+            'instance_id': raw_data[4],
+            'fkt_id': raw_data[5] >> 4,
+            'op_type': raw_data[5] & 0xf,
+            'tel_id': (raw_data[6] & 0xf) >> 4,
+            'tel_len': raw_data[6] & 0xf,
+            'data': message
+        }
+        self.recv_most_message(most_message)
+
+class PiMOSTThread(threading.Thread):
+    def __init__(self):
+        super(PiMOSTThread, self).__init__()
+        self.pimost = PiMost(self.recv_most_message)
+        self.client = socketio.Client()
+        self._stop_event = threading.Event()
+        self.daemon = True
+
+    def run(self):
+        try:
+            while not self._stop_event.is_set():
+                # Connect to socketIO 
+                if not self.client.connected:
+                    self.connect_to_socketio()
+                
+                # Connect to PiMost
+                if not self.pimost.connected:
+                    if shared_state.verbose:
+                        print("Attempting to connect to PiMost device")
+                    self.pimost.find_port()           
+
+                # Keep checking if connection is up
+                time.sleep(10)
+        except KeyboardInterrupt:
+            pass
+
+    def connect_to_socketio(self):
+        max_retries = 10
+        current_retry = 0
+        while not self.client.connected and current_retry < max_retries:
+            try:
+                self.client.connect('http://localhost:4001', namespaces=['/most'])
+            except Exception as e:
+                print(f"Socket.IO connection failed. Retry {current_retry}/{max_retries}. Error: {e}")
+                time.sleep(.5)
+                current_retry += 1
+        if shared_state.verbose:
+            print("MOST connected to Socket.IO" if self.client.connected else "MOST failed to connect to Socket.IO.")
+
+    # callback from PiMost class
+    def recv_most_message(self, most_message):
+        self.client.emit("most_message", most_message, namespace="/most")
+        if shared_state.verbose:
+            print("most message received")
+            #print(most_message)
+
+    def force_switch(self):
+        if self.pimost.connected:
+            print("pimost connected, force switching")
+            self.pimost.force_switch()
+        else:
+            print("PiMost device not connected! Cannot send force_switch")
+        
+    def stop_thread(self):
+        print("Stopping PiMost thread.")
+        time.sleep(.5)
+        self._stop_event.set()

--- a/backend/pimost.py
+++ b/backend/pimost.py
@@ -71,21 +71,24 @@ class PiMost:
                     self.port = None
 
     def parse_message(self, data, length):
-        raw_data = struct.unpack_from('>BBBBBHB', data, 0)
-        message = data[8:len(data)]
-        most_message = {
-            'type': raw_data[0],
-            'source_address_high': raw_data[1],
-            'source_address_low': raw_data[2],
-            'fBlock_id': raw_data[3],
-            'instance_id': raw_data[4],
-            'fkt_id': raw_data[5] >> 4,
-            'op_type': raw_data[5] & 0xf,
-            'tel_id': (raw_data[6] & 0xf) >> 4,
-            'tel_len': raw_data[6] & 0xf,
-            'data': message
-        }
-        self.recv_most_message(most_message)
+        try: 
+            raw_data = struct.unpack_from('>BBBBBHB', data, 0)
+            message = data[8:len(data)]
+            most_message = {
+                'type': raw_data[0],
+                'source_address_high': raw_data[1],
+                'source_address_low': raw_data[2],
+                'fBlock_id': raw_data[3],
+                'instance_id': raw_data[4],
+                'fkt_id': raw_data[5] >> 4,
+                'op_type': raw_data[5] & 0xf,
+                'tel_id': (raw_data[6] & 0xf) >> 4,
+                'tel_len': raw_data[6] & 0xf,
+                'data': message
+            }
+            self.recv_most_message(most_message)
+        except Exception as e:
+            print("Error parsing MOST message: ", e)
 
 class PiMOSTThread(threading.Thread):
     def __init__(self):
@@ -116,7 +119,7 @@ class PiMOSTThread(threading.Thread):
     def connect_to_socketio(self):
         max_retries = 10
         current_retry = 0
-        while not self.client.connected and current_retry < max_retries:
+        while not self._stop_event.is_set() and not self.client.connected and current_retry < max_retries:
             try:
                 self.client.connect('http://localhost:4001', namespaces=['/most'])
             except Exception as e:

--- a/backend/server.py
+++ b/backend/server.py
@@ -20,7 +20,7 @@ CORS(server, resources={r"/*": {"origins": "*"}})
 socketio = SocketIO(server, cors_allowed_origins="*", async_mode='eventlet')
 
 # Define modules
-modules = ["app", "mmi", "can", "lin", "adc", "rti"]
+modules = ["app", "mmi", "can", "lin", "adc", "rti", "most"]
 
 class ServerThread(threading.Thread):
     def __init__(self):
@@ -202,3 +202,23 @@ class ServerThread(threading.Thread):
             socketio.emit('ign', shared_state.ign_state.is_set(), namespace="/sys")
         else:
             if (shared_state.verbose): print('Unknown action:', args)
+
+    @socketio.on('force_switch', namespace='/most')
+    def handle_force_switch():
+        if shared_state.verbose:
+            print("Frontend requested PiMost force switch")
+
+        most_thread = shared_state.THREADS.get("pimost", None)
+
+        if most_thread and most_thread.is_alive():
+            try:
+                most_thread.force_switch()
+            except Exception as e:
+                print("Error calling PiMost force_switch from server.py:", e)
+
+    ## not really used yet, we can perform certain actions based on MOST messages here or in pimost.py
+    @socketio.on('most_message', namespace='/most')
+    def print_most_message(args):
+        print("received most message on most namespace")
+        print(args)
+

--- a/backend/shared/shared_state.py
+++ b/backend/shared/shared_state.py
@@ -13,6 +13,7 @@ class SharedState:
 
         self.vCan = False
         self.vLin = False
+        self.pimost = True
 
         self.vite = True
         self.isKiosk = True
@@ -52,6 +53,7 @@ class SharedState:
             "rti":      None,
             "ign":      None,
             "vcan":     None,
+            "pimost":   None,
         }
 
 shared_state = SharedState()

--- a/backend/shared/shared_state.py
+++ b/backend/shared/shared_state.py
@@ -13,7 +13,7 @@ class SharedState:
 
         self.vCan = False
         self.vLin = False
-        self.pimost = True
+        self.pimost = False
 
         self.vite = True
         self.isKiosk = True

--- a/frontend/src/app/pages/settings/Settings.tsx
+++ b/frontend/src/app/pages/settings/Settings.tsx
@@ -19,6 +19,7 @@ const canChannel = io("ws://localhost:4001/can")
 const linChannel = io("ws://localhost:4001/lin")
 const adcChannel = io("ws://localhost:4001/adc")
 const rtiChannel = io("ws://localhost:4001/rti")
+const mostChannel = io("ws://localhost:4001/most")
 
 const Container = styled.div`
     flex: 1;
@@ -216,6 +217,9 @@ const Settings = () => {
     setReset(true)
   }
 
+  function sendForceSwitchMostMessage () {
+    mostChannel.emit("force_switch");
+  }
 
   const checkUpdate = async () => {
     const githubRepo = "BoostedMoose/v-link"; // Replace with your GitHub repository
@@ -548,9 +552,9 @@ const Settings = () => {
               </div>
 
               <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', gap: '10px' }}>
-                <Button onClick={() => { systemTask('reset') }} style={{ height: '100%' }}> Reset </Button>
-                <Button onClick={() => { systemTask('reboot') }} style={{ height: '100%' }}> Reboot </Button>
                 <Button onClick={() => { checkUpdate() }} style={{ height: '100%' }}> Update </Button>
+                <Button onClick={() => { systemTask('reboot') }} style={{ height: '100%' }}> Reboot </Button>
+                <Button onClick={() => { sendForceSwitchMostMessage() }} style={{ height: '100%' }}> Switch PiMost </Button>
               </div>
             </div>
             <p />


### PR DESCRIPTION
Replaces the `reset`-button in settings with a button that force-switches the audio back to the PiMost, which is the only way to get CarPlay/AA audio back if the PiMost is not the current source anymore. This can happen if you turn off the radio, switch source to AUX/FM, etc.

The force-switch functionality is provided by [https://github.com/rhysmorgan134/pymost-client](https://github.com/rhysmorgan134/pymost-client)

Tested in a 2008 C30 with firmware v0.1.0 of the PiMost USB-C.