### PR TITLE
Fixing CAN initialization and naming

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -209,7 +209,6 @@ dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=24
 dtoverlay=mcp2515-can2,oscillator=16000000,interrupt=22
 
 #Configure IGN logic
-dtoverlay=pi3-disable-bt
 dtoverlay=gpio-poweroff,gpiopin=0
 
 #No Splash on boot
@@ -236,7 +235,6 @@ dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=24
 dtoverlay=mcp2515-can2,oscillator=16000000,interrupt=22
 
 #Configure IGN logic
-dtoverlay=pi3-disable-bt
 dtoverlay=gpio-poweroff,gpiopin=0
 
 #No Splash on boot
@@ -272,33 +270,66 @@ EOF'
     fi
 fi
 
-# Step 7: Create V-Link systemd service
-if confirm_action "create systemd services for V-Link"; then
-    sudo bash -c "cat > /etc/systemd/system/v-link.service <<EOF
-[Unit]
-Description=V-Link Services
-After=network.target
+# Step 7: Configure systemd-networkd for CAN interfaces
+if confirm_action "configure systemd-networkd for V-Link CAN interfaces"; then
+    echo "Creating systemd-networkd configuration files for can1 and can2..."
 
-[Service]
-Type=oneshot
-ExecStartPre=/bin/bash -c '/usr/sbin/ip link set can0 down || true; /usr/sbin/ip link set can1 down || true'
-ExecStart=/bin/bash -c '/usr/sbin/modprobe uinput; /usr/sbin/ip link set can0 up type can bitrate 500000; /usr/sbin/ip link set can1 up type can bitrate 125000'
-ExecStop=/bin/bash -c '/usr/sbin/ip link set can0 down; /usr/sbin/ip link set can1 down'
-RemainAfterExit=true
+    # Create can1.netdev
+    sudo tee /etc/systemd/network/can1.network > /dev/null <<EOF
+[Match]
+Name=can1
 
-[Install]
-WantedBy=multi-user.target
-EOF"
-        sudo systemctl enable v-link.service && systemctl daemon-reload
+[CAN]
+BitRate=125000
+
+[Network]
+# raw CAN
+EOF
+
+    # Create can2.netdev
+    sudo tee /etc/systemd/network/can2.network > /dev/null <<EOF
+[Match]
+Name=can2
+
+[CAN]
+BitRate=500000
+
+[Network]
+# raw CAN
+EOF
+
+    # Enable and restart systemd-networkd
+    echo "Enabling and restarting systemd-networkd..."
+    sudo systemctl enable systemd-networkd
+    sudo systemctl daemon-reexec
+    sudo systemctl restart systemd-networkd
+
+    echo "Systemd-networkd now manages can1 and can2 automatically at boot."
 fi
 
-# Step 8: Create V-Link udev rules
+# Step 8: Load uinput kernel module at boot
+if confirm_action "enable uinput kernel module at boot"; then
+    echo "Creating /etc/modules-load.d/uinput.conf..."
+    echo "uinput" | sudo tee /etc/modules-load.d/uinput.conf > /dev/null
+
+    if [[ $? -eq 0 ]]; then
+        echo -e "uinput module will now be auto-loaded at boot.\n"
+    else
+        echo -e "Failed to create uinput.conf.\n"
+    fi
+fi
+
+# Step 9: Create V-Link udev rules
 if confirm_action "create udev rules for V-Link"; then
     echo "Creating combined udev rule"
     RULE_FILE=/etc/udev/rules.d/42-v-link.rules
 
     # Write all rules into a single file
     echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1314", ATTR{idProduct}=="152*", MODE="0660", GROUP="plugdev"' | sudo tee $RULE_FILE
+
+    echo 'SUBSYSTEM=="net", ACTION=="add", KERNELS=="spi0.1", NAME="can1"' | sudo tee $RULE_FILE
+    echo 'SUBSYSTEM=="net", ACTION=="add", KERNELS=="spi0.2", NAME="can2"' | sudo tee $RULE_FILE
+    
     echo 'KERNEL=="ttyS0", MODE="0660", GROUP="plugdev"' | sudo tee -a $RULE_FILE
     echo 'KERNEL=="uinput", MODE="0660", GROUP="plugdev"' | sudo tee -a $RULE_FILE
 
@@ -309,46 +340,16 @@ if confirm_action "create udev rules for V-Link"; then
     fi
 fi
 
-# Step 9: Create autostart file for V-Link
+# Step 10: Create autostart file for V-Link
 if confirm_action "create autostart file for V-Link"; then
     output_path="/home/$CURRENT_USER/v-link"
 
     sudo bash -c "cat > /etc/xdg/autostart/v-link.desktop <<EOL
 [Desktop Entry]
 Name=V-Link
-Exec=sh -c 'sudo systemctl restart v-link.service && python $output_path/V-Link.py'
+Exec=sh -c 'python $output_path/V-Link.py'
 Type=Application
 EOL"
-fi
-
-# Step 10: Enable sudo permission for systemctl restart
-if confirm_action "enable V-Link to restart v-link.service as sudo"; then
-    SERVICE_NAME="v-link"
-    SUDOERS_FILE="/etc/sudoers.d/$SERVICE_NAME"
-    CURRENT_USER=$(whoami)
-
-    # Check if the sudoers file already exists
-    if [[ -f "$SUDOERS_FILE" ]]; then
-        echo "Sudoers file for $SERVICE_NAME already exists at $SUDOERS_FILE. Skipping creation."
-    else
-        echo "Creating sudoers rule for user '$CURRENT_USER' to restart '$SERVICE_NAME'..."
-
-        # Write the rule to a new sudoers file
-        {
-            echo "# Allow $CURRENT_USER to restart $SERVICE_NAME without a password"
-            echo "$CURRENT_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart $SERVICE_NAME.service"
-        } > "$SUDOERS_FILE"
-
-        # Validate the sudoers file syntax
-        if visudo -c -f "$SUDOERS_FILE" &>/dev/null; then
-            echo "Sudoers rule added successfully in $SUDOERS_FILE."
-            sudo chmod 0440 /etc/sudoers.d/$SERVICE_NAME
-        else
-            echo "Error: Sudoers rule syntax is invalid. Aborting."
-            rm -f "$SUDOERS_FILE"
-            exit 1
-        fi
-    fi
 fi
 
 # Step 11: Remove logo and cursor on boot

--- a/Install.sh
+++ b/Install.sh
@@ -299,11 +299,8 @@ BitRate=500000
 EOF
 
     # Enable and restart systemd-networkd
-    echo "Enabling and restarting systemd-networkd..."
     sudo systemctl enable systemd-networkd
-    sudo systemctl daemon-reexec
-    sudo systemctl restart systemd-networkd
-
+    
     echo "Systemd-networkd now manages can1 and can2 automatically at boot."
 fi
 

--- a/backend/can.py
+++ b/backend/can.py
@@ -100,7 +100,7 @@ class CANThread(threading.Thread):
 
     def initialize_canbus(self):
         for iface in self.config.interfaces:
-            channel = iface["channel"] # can0, can1, etc
+            channel = iface["channel"] # can1, can2, etc
             is_extended = iface["is_extended"]
 
             try:

--- a/backend/config/can.json
+++ b/backend/config/can.json
@@ -5,7 +5,7 @@
         {
             "enabled": true,
             "bustype": "socketcan",
-            "channel": "can0",
+            "channel": "can2",
             "is_extended": true,
             "bitrate": 125000
         },
@@ -51,7 +51,7 @@
     ],
     "sensors": {
         "boost": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": true,
             "type": "diagnostic",
             "parameter": [
@@ -73,7 +73,7 @@
             "limit_start": 1.5
         },
         "intake": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": true,
             "type": "diagnostic",
             "parameter": [
@@ -95,7 +95,7 @@
             "limit_start": 60
         },
         "coolant": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": true,
             "type": "diagnostic",
             "parameter": [
@@ -117,7 +117,7 @@
             "limit_start": 100
         },
         "voltage": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": true,
             "type": "diagnostic",
             "parameter": [
@@ -139,7 +139,7 @@
             "limit_start": 16
         },
         "lambda1": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": false,
             "type": "diagnostic",
             "parameter": [
@@ -161,7 +161,7 @@
             "limit_start": 2
         },
         "lambda2": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": false,
             "type": "diagnostic",
             "parameter": [
@@ -183,7 +183,7 @@
             "limit_start": 2
         },
         "rpm": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": true,
             "type": "diagnostic",
             "parameter": [
@@ -205,7 +205,7 @@
             "limit_start":7000
         },
         "speed": {
-            "interface": "can0",
+            "interface": "can2",
             "enabled": false,
             "type": "diagnostic",
             "parameter": [
@@ -229,7 +229,7 @@
     },
     "controls": {
         "enabled": false,
-        "interface": "can0",
+        "interface": "can2",
         "rep_id": "0x0131726C",
         "zero_message": ["0x00", "0x00", "0x3F"],
         "control_byte_count": 2,


### PR DESCRIPTION
This commit should fix the issue where sometimes can interfaces and uinput are not correctly initialized on boot. The devicenames correctly reflect the names on the HAT now so everything is consistent.

| SPI     | SYSTEM | HAT   |
|---------|--------|-------|
| spi0.1  | can1   | CAN 1 |
| spi0.2  | can2   | CAN 2 |

These changes include getting rid of the v-link.service and create 2 new files under /etc/systemd/network as well as a new file at /etc/modules-load.d/ to configure CAN and uinput on boot.

The installer has been updated accordingly.